### PR TITLE
fix: use configured encoding for output file

### DIFF
--- a/src/repod/core.py
+++ b/src/repod/core.py
@@ -20,7 +20,7 @@ class DumperConfig:
     ignore_file: Optional[Path] = None
     preamble_file: Optional[Path] = None
     include_tree: bool = True
-    encoding: str = "utf-8" 
+    encoding: str = "utf-8"
     default_preamble: str = """
     # Repository Content Dump
 
@@ -66,52 +66,44 @@ class RepositoryDumper:
 
     # default ignore patterns
     DEFAULT_IGNORE_PATTERNS = [
-    # --- Project-specific files ---
-    ".rpdignore",
-    "repod.md",
-
-    # --- Git-related files ---
-    ".git/*",
-    ".gitignore",
-
-    # --- OS-specific metadata ---
-    ".DS_Store",
-    "Thumbs.db",
-    "Desktop.ini",
-
-    # --- IDE/editor settings ---
-    ".idea/*",
-    ".vscode/*",
-    ".project",
-    ".classpath",
-    ".settings/*",
-
-    # --- Python-related caches/build artifacts ---
-    ".tox/*",
-    "*.pyc",
-    "__pycache__/*",
-    ".mypy_cache/*",
-    ".ruff_cache/*",
-    "*.whl",
-    ".env*",   # May contain sensitive information
-    ".venv/*", # Python virtual environment
-
-    # --- Archives ---
-    "*.tar",
-    "*.tar.gz",
-
-    # --- Media files (images) ---
-    "*.png",
-    "*.jpeg",
-    "*.jpg",
-
-    # --- Log files, binaries, lock files ---
-    "*.log",
-    "*bin/*",
-    "*.lock",
-
-    # --- Node.js dependencies ---
-    "*/node_modules/*",
+        # --- Project-specific files ---
+        ".rpdignore",
+        "repod.md",
+        # --- Git-related files ---
+        ".git/*",
+        ".gitignore",
+        # --- OS-specific metadata ---
+        ".DS_Store",
+        "Thumbs.db",
+        "Desktop.ini",
+        # --- IDE/editor settings ---
+        ".idea/*",
+        ".vscode/*",
+        ".project",
+        ".classpath",
+        ".settings/*",
+        # --- Python-related caches/build artifacts ---
+        ".tox/*",
+        "*.pyc",
+        "__pycache__/*",
+        ".mypy_cache/*",
+        ".ruff_cache/*",
+        "*.whl",
+        ".env*",  # May contain sensitive information
+        ".venv/*",  # Python virtual environment
+        # --- Archives ---
+        "*.tar",
+        "*.tar.gz",
+        # --- Media files (images) ---
+        "*.png",
+        "*.jpeg",
+        "*.jpg",
+        # --- Log files, binaries, lock files ---
+        "*.log",
+        "*bin/*",
+        "*.lock",
+        # --- Node.js dependencies ---
+        "*/node_modules/*",
     ]
 
     def __init__(self, config: DumperConfig):
@@ -130,7 +122,12 @@ class RepositoryDumper:
             return []
 
         try:
-            with open(self.config.ignore_file, "r", encoding=self.config.encoding, errors="ignore") as f:
+            with open(
+                self.config.ignore_file,
+                "r",
+                encoding=self.config.encoding,
+                errors="ignore",
+            ) as f:
                 return [
                     line.strip()
                     for line in f
@@ -185,7 +182,12 @@ class RepositoryDumper:
         preamble = self.config.default_preamble
         if self.config.preamble_file:
             try:
-                with open(self.config.preamble_file, "r", encoding=self.config.encoding, errors="ignore") as pf:
+                with open(
+                    self.config.preamble_file,
+                    "r",
+                    encoding=self.config.encoding,
+                    errors="ignore",
+                ) as pf:
                     preamble = pf.read().strip()
             except Exception as e:
                 logger.error(f"Error reading preamble file: {e}")
@@ -206,7 +208,9 @@ class RepositoryDumper:
             if self._should_ignore(str(relative_path)):
                 return
 
-            with open(file_path, "r", encoding=self.config.encoding, errors="ignore") as f:
+            with open(
+                file_path, "r", encoding=self.config.encoding, errors="ignore"
+            ) as f:
                 content = f.read()
                 lang = self._get_file_language(file_path)
                 output_file.write(f"### {relative_path}\n\n")
@@ -225,7 +229,9 @@ class RepositoryDumper:
             files = [f for f in self.config.repo_path.rglob("*") if f.is_file()]
             total_files = len(files)
 
-            with open(self.config.output_path, "w", encoding="utf-8") as output_file:
+            with open(
+                self.config.output_path, "w", encoding=self.config.encoding
+            ) as output_file:
                 self._write_preamble(output_file)
 
                 with Progress() as progress:


### PR DESCRIPTION
Previously the output file was hardcoded to use utf-8 encoding. This change makes it use the configured encoding from DumperConfig for consistency.